### PR TITLE
trim white spaces, make sure all doubles are declared with _mk

### DIFF
--- a/src/dtu_we_controller/dtu_we_controller.f90
+++ b/src/dtu_we_controller/dtu_we_controller.f90
@@ -29,7 +29,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    !  constant   2 ; Minimum rotor speed [rad/s]
    !  constant   3 ; Rated rotor speed [rad/s]
    !  constant   4 ; Maximum allowable generator torque [Nm]
-   !  constant   5 ; Minimum pitch angle, PitchMin [deg], 
+   !  constant   5 ; Minimum pitch angle, PitchMin [deg],
    !               ; if |PitchMin|>90, then a table of <wsp,PitchMin> is read ;
    !               ; from a file named 'wptable.n', where n=int(PitchMin)
    !  constant   6 ; Maximum pitch angle [deg]
@@ -76,12 +76,12 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    ! Overspeed
    !  constant  39 ; Overspeed percentage before initiating turbine controller alarm (shut-down) [%]
    ! Additional non-linear pitch control term (not used when all zero)
-   !  constant  40 ; Err0 [rad/s] 
+   !  constant  40 ; Err0 [rad/s]
    !  constant  41 ; ErrDot0 [rad/s^2]
    !  constant  42 ; PitNonLin1 [rad/s]
    ! Storm control command
    !  constant  43 ; Wind speed 'Vstorm' above which derating of rotor speed is used [m/s]
-   !  constant  44 ; Cut-out wind speed (only used for derating of rotor speed in storm) [m/s]	  
+   !  constant  44 ; Cut-out wind speed (only used for derating of rotor speed in storm) [m/s]
    ! Safety system parameters
    !  constant  45 ; Overspeed percentage before initiating safety system alarm (shut-down) [%]
    !  constant  46 ; Max low-pass filtered tower top acceleration level before initiating turbine controller alarm (shut-down) [m/s^2]
@@ -99,7 +99,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    ! Output array2 contains nothing for init
    !
    ! Overall parameters
-   PeRated             = array1( 1)*1.d3
+   PeRated             = array1( 1)*1000.0_mk
    GenSpeedRefMin      = array1( 2)
    GenSpeedRefMax      = array1( 3)
    GenTorqueMax        = array1( 4)
@@ -156,7 +156,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    ! Expert parameters (keep default values unless otherwise given)
    SwitchVar%pitang_lower   = array1(33)*degrad
    SwitchVar%pitang_upper   = array1(34)*degrad
-   SwitchVar%rel_sp_open_Qg = array1(35)*1.d-2
+   SwitchVar%rel_sp_open_Qg = array1(35)*0.01_mk
    wspfirstordervar%tau     = array1(36)*2.0_mk*pi/GenSpeedRefMax
    pitchfirstordervar%tau   = array1(37)*2.0_mk*pi/GenSpeedRefMax
    ! Drivetrain damper
@@ -175,7 +175,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    MoniVar%rystevagtfirstordervar%tau = 2.0_mk*pi/GenSpeedRefMax
    SafetySystemVar%rystevagtfirstordervar%tau = 2.0_mk*pi/GenSpeedRefMax
    ! Wind speed table
-   if (dabs(minimum_pitch_angle).lt.90.0_mk*degrad) then 
+   if (dabs(minimum_pitch_angle).lt.90.0_mk*degrad) then
      OPdatavar%lines=2
      OPdatavar%wpdata(1,1) = 0.0_mk
      OPdatavar%wpdata(2,1) = 99.0_mk
@@ -189,7 +189,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
        read(88,*,iostat=ifejl) OPdatavar%lines
        if (ifejl.eq.0) then
          do i=1,OPdatavar%lines
-           read(88,*,iostat=ifejl) OPdatavar%wpdata(i,1),OPdatavar%wpdata(i,2) 
+           read(88,*,iostat=ifejl) OPdatavar%wpdata(i,1),OPdatavar%wpdata(i,2)
            if (ifejl.ne.0) then
              write(6,*) ' *** ERROR *** Could not read lines in minimum '&
                       //'pitch table in file wpdata.'//trim(adjustl(text32))
@@ -251,13 +251,13 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    ! -Drive train mode damper
    DT_damper%notch%f0   = 10.0_mk*DT_damper%notch%f0
    DT_damper%bandpass%zeta = 0.7_mk
-   DT_damper%notch%zeta2   = 0.01
+   DT_damper%notch%zeta2   = 0.01_mk
    DT_damper%Td            = 0.0_mk
    ! -Tower top fore-aft mode damper
    TTfa_damper%bandpass%f0   = 1.0_mk
    TTfa_damper%notch%f0      = 1.0_mk
    TTfa_damper%bandpass%zeta = 0.7_mk
-   TTfa_damper%notch%zeta2   = 0.01
+   TTfa_damper%notch%zeta2   = 0.01_mk
    TTfa_damper%gain          = 0.0_mk
    TTfa_damper%Td            = 1.0_mk
    TTfa_PWRfirstordervar%tau = 1.0_mk
@@ -269,7 +269,7 @@ subroutine init_regulation(array1, array2) bind(c, name='init_regulation')
    ! -"Rystevagt" monitor for Safety System
    SafetySystemVar%RysteVagtLevel = MoniVar%RysteVagtLevel*1.1_mk
    ! Gear Ratio
-   GearRatio = 1
+   GearRatio = 1.0_mk
    ! Initiate the dynamic variables
    stepno = 0
    time_old = 0.0_mk
@@ -295,7 +295,7 @@ subroutine init_regulation_advanced(array1, array2) bind(c,name='init_regulation
    !  constant  58 ; Frequency of notch filter [Hz]
    !  constant  59 ; Damping of BP filter [-]
    !  constant  60 ; Damping of notch filter [-]
-   !  constant  61 ; Phase lag of damper [s] =>  max 40*dt 
+   !  constant  61 ; Phase lag of damper [s] =>  max 40*dt
    ! Fore-aft Tower mode damper
    !  constant  62 ; Frequency of BP filter [Hz]
    !  constant  63 ; Frequency of notch fiter [Hz]
@@ -335,7 +335,7 @@ subroutine init_regulation_advanced(array1, array2) bind(c,name='init_regulation
    TTfa_damper%notch%zeta2   = array1(65)
    TTfa_damper%gain          = array1(66)
    TTfa_damper%Td            = array1(67)
-   TTfa_PWRfirstordervar%tau = 1.0_mk/(2.0_mk*pi*array1(68)) 
+   TTfa_PWRfirstordervar%tau = 1.0_mk/(2.0_mk*pi*array1(68))
    TTfa_PWR_lower = array1(69)
    TTfa_PWR_upper = array1(70)
    !Tower top side-to- mode filter
@@ -355,7 +355,7 @@ end subroutine init_regulation_advanced
 !**************************************************************************************************
 subroutine update_regulation(array1, array2) bind(c,name='update_regulation')
    !
-   ! Controller interface. 
+   ! Controller interface.
    !  - sets DLL inputs/outputs.
    !  - sets controller timers.
    !  - calls the safety system monitor (higher level).
@@ -436,12 +436,12 @@ subroutine update_regulation(array1, array2) bind(c,name='update_regulation')
    PitchVect(3) = array1(5)
    ! Wind speed as horizontal vector sum
    wsp = dsqrt(array1(6)**2 + array1(7)**2)
-   if (stepno.eq.1) then 
+   if (stepno.eq.1) then
       Pe = 0.0_mk ! Elec. power
-      GridFlag = 0 ! Grid flag
+      GridFlag = 0.0_mk ! Grid flag
    else
       Pe=array1(9) ! Elec. power
-      GridFlag = int(array1(10)) ! Grid flag
+      GridFlag = array1(10) ! Grid flag
    endif
    ! Tower top acceleration
    TT_acc(1) = array1(11)
@@ -501,13 +501,13 @@ subroutine update_regulation(array1, array2) bind(c,name='update_regulation')
    array2(19) = dump_array(15)         !   19: Minimum limit of pitch                   [rad]
    array2(20) = dump_array(16)         !   20: Maximum limit of pitch                   [rad]
    array2(21) = dump_array(17)         !   21: Torque reference from DT damper          [Nm]
-   array2(22) = int(dump_array(18))    !   22: Status signal                            [-]
+   array2(22) = dump_array(18)         !   22: Status signal                            [-]
    array2(23) = dump_array(19)         !   23: Total added pitch rate                   [rad/s]
    array2(24) = dump_array(20)         !   24: Filtered pitch angle                     [rad]
-   array2(25) = ActiveMechBrake      !   25: Flag for mechnical brake                 [0=off/1=on]
+   array2(25) = ActiveMechBrake        !   25: Flag for mechnical brake                 [0=off/1=on]
    array2(26) = EmergPitchStop         !   26: Flag for emergency pitch stop            [0=off/1=on]
    array2(27) = dump_array(23)         !   27: LP filtered acceleration level           [m/s^2]
-   array2(28) = int(dump_array(24))    !   28: Rotor speed exlusion zone region         [-]
+   array2(28) = dump_array(24)         !   28: Rotor speed exlusion zone region         [-]
    array2(29) = dump_array(25)         !   29: Filtered tower top acc. for tower damper [m/s^2]
    array2(30) = dump_array(26)         !   30: Reference pitch from tower damper        [rad]
    return

--- a/src/dtu_we_controller/dtu_we_controller_fcns.f90
+++ b/src/dtu_we_controller/dtu_we_controller_fcns.f90
@@ -1,6 +1,6 @@
 module dtu_we_controller_fcns
    !
-   ! Module with general function that are specific of the DTU Wind Energy Controller. Types are 
+   ! Module with general function that are specific of the DTU Wind Energy Controller. Types are
    ! also defined in this module.
    !
    use misc_mod
@@ -73,7 +73,7 @@ function switch_spline(x, x0, x1)
       if (x .lt. x0) then
          switch_spline = 0.0_mk
       elseif (x .gt. x1) then
-         switch_spline = 1.0_mk 
+         switch_spline = 1.0_mk
       else
          switch_spline = 2.0_mk/(-x1 + x0)**3*x**3 + (-3.0_mk*x0 - 3.0_mk*x1)/(-x1 + x0)**3*x**2&
                          +6.0_mk*x1*x0/(-x1 + x0)**3*x + (x0 - 3.0_mk*x1)*x0**2/(-x1 + x0)**3
@@ -85,9 +85,9 @@ end function switch_spline
 function interpolate(x, x0, x1, f0, f1)
    ! Linear interpolation of x through the points (x0, f0) and (x1, f1)
    real(mk) interpolate, x, x0, x1, f0, f1
-   if (x0 .eq. x1) then 
+   if (x0 .eq. x1) then
       interpolate = f0
-   else 
+   else
       interpolate = (x - x1)/(x0 - x1)*f0 + (x - x0)/(x1 - x0)*f1
    endif
    return
@@ -103,7 +103,7 @@ function GetOptiPitch(wsp)
    do while((OPdatavar%wpdata(i, 1) .le. wsp) .and. (i .le. OPdatavar%lines))
       i=i+1
    enddo
-   if (i.eq.1) then 
+   if (i.eq.1) then
       GetOptiPitch = OPdatavar%wpdata(1, 2)
    elseif (i .gt. OPdatavar%lines) then
       GetOptiPitch = OPdatavar%wpdata(OPdatavar%lines, 2)
@@ -126,7 +126,7 @@ function PID(stepno, dt, kgain, PIDvar, error)
    type(Tpidvar) PIDvar
    ! Local vars
    real(mk) eps
-   parameter(eps = 1.d-6)
+   parameter(eps = 1.d-6_mk)
    ! Initiate
    if (stepno.eq.1) then
       PIDvar%outset1 = 0.0_mk
@@ -151,9 +151,9 @@ function PID(stepno, dt, kgain, PIDvar, error)
    ! Sum to up
    PIDvar%outres = PIDvar%outset+PIDvar%outpro + PIDvar%outdif
    ! Satisfy hard limits
-   if (PIDvar%outres .lt. PIDvar%outmin) then 
+   if (PIDvar%outres .lt. PIDvar%outmin) then
       PIDvar%outres = PIDvar%outmin
-   elseif (PIDvar%outres .gt. PIDvar%outmax) then 
+   elseif (PIDvar%outres .gt. PIDvar%outmax) then
       PIDvar%outres = PIDvar%outmax
    endif
    ! Satisfy max velocity
@@ -168,9 +168,9 @@ function PID(stepno, dt, kgain, PIDvar, error)
    PIDvar%error1 = error
    PIDvar%stepno1 = stepno
    ! Set output
-   if (stepno .eq. 0) then 
-      PID = 0
-   else 
+   if (stepno .eq. 0) then
+      PID = 0.0_mk
+   else
       PID = PIDvar%outres
    endif
    return
@@ -184,7 +184,7 @@ function PID2(stepno,dt,kgain,PIDvar,error,added_term)
    type(Tpid2var) PIDvar
    ! Local vars
    real(mk) eps
-   parameter(eps=1.d-6)
+   parameter(eps=1.d-6_mk)
    ! Initiate
    if (stepno .eq. 1) then
       PIDvar%outset1 = 0.0_mk
@@ -211,9 +211,9 @@ function PID2(stepno,dt,kgain,PIDvar,error,added_term)
    ! Sum up
    PIDvar%outres = PIDvar%outset + PIDvar%outpro + PIDvar%outdif
    ! Satisfy hard limits
-   if (PIDvar%outres .lt. PIDvar%outmin) then 
+   if (PIDvar%outres .lt. PIDvar%outmin) then
       PIDvar%outres = PIDvar%outmin
-   elseif (PIDvar%outres .gt. PIDvar%outmax) then 
+   elseif (PIDvar%outres .gt. PIDvar%outmax) then
       PIDvar%outres = PIDvar%outmax
    endif
    ! Write out values if the output is not-a-number
@@ -242,9 +242,9 @@ function PID2(stepno,dt,kgain,PIDvar,error,added_term)
    PIDvar%error1 = error
    PIDvar%stepno1 = stepno
    ! Set output
-   if (stepno .eq. 0) then 
-      PID2 = 0
-   else 
+   if (stepno .eq. 0) then
+      PID2 = 0.0_mk
+   else
       PID2 = PIDvar%outres
    endif
    return

--- a/src/dtu_we_controller/misc_mod.f90
+++ b/src/dtu_we_controller/misc_mod.f90
@@ -36,7 +36,7 @@ module misc_mod
    end type Tbandpassfilt
    !  Time delay
    type Ttdelay
-      real(mk) xz(40) 
+      real(mk) xz(40)
       integer stepno1
    end type Ttdelay
 contains
@@ -46,7 +46,7 @@ function lowpass1orderfilt(dt, stepno, filt, x)
    integer stepno
    real(mk) lowpass1orderfilt, dt, x, y, a1, b1, b0, tau
    type(Tfirstordervar) filt
-   ! Step 
+   ! Step
    if ((stepno .eq. 1) .and. (stepno .gt. filt%stepno1)) then
       filt%x1_old = x
       filt%y1_old = x
@@ -218,7 +218,7 @@ function timedelay(dt, stepno, filt, Td, x)
    real(mk) x, timedelay, dt, Td
    type(Ttdelay) filt
    n = nint(Td/dt)
-   ! Step 
+   ! Step
    if ((stepno .eq. 1)) then
       do k = 1, 40
          filt%xz(k) = x

--- a/src/dtu_we_controller/turbine_controller.f90
+++ b/src/dtu_we_controller/turbine_controller.f90
@@ -6,7 +6,7 @@ module turbine_controller_mod
    implicit none
    ! Parameters
    logical const_power, generator_cutin
-   integer PartialLoadControlMode, stoptype, GearRatio
+   integer PartialLoadControlMode, stoptype
    real(mk) deltat
    real(mk) GenSpeedRefMax, GenSpeedRefMin, PeRated, GenTorqueRated, PitchStopAng, GenTorqueMax
    real(mk) TTfa_PWR_lower, TTfa_PWR_upper
@@ -17,7 +17,7 @@ module turbine_controller_mod
    integer :: stepno = 0, w_region = 0
    real(mk) AddedPitchRate, PitchColRef0, GenTorqueRef0, PitchColRefOld, GenTorqueRefOld
    real(mk) TimerGenCutin, TimerStartup, TimerExcl, TimerShutdown, TimerShutdown2
-   real(mk) GenSpeed_at_stop, GenTorque_at_stop
+   real(mk) GenSpeed_at_stop, GenTorque_at_stop, GearRatio
    real(mk) excl_flag
    ! Types
    type(Tlowpass2order), save :: omega2ordervar
@@ -125,7 +125,7 @@ subroutine normal_operation(GenSpeed, PitchVect, wsp, Pe, TTfa_acc, GenTorqueRef
    ! Low-pass filtering of the mean pitch angle for gain scheduling
    PitchMeanFilt = lowpass1orderfilt(deltat, stepno, pitchfirstordervar, PitchMean)
    PitchMeanFilt = min(PitchMeanFilt, 30.0_mk*degrad)
-   ! Low-pass filtering of the nacelle wind speed 
+   ! Low-pass filtering of the nacelle wind speed
    WSPfilt = lowpass1orderfilt(deltat, stepno, wspfirstordervar, wsp)
    ! Minimum pitch angle may vary with filtered wind speed
    PitchMin = GetOptiPitch(WSPfilt)
@@ -140,7 +140,7 @@ subroutine normal_operation(GenSpeed, PitchVect, wsp, Pe, TTfa_acc, GenTorqueRef
    endif
    GenSpeedRef_full = max(min(GenSpeedRef_full, GenSpeedRefMax), GenSpeedRefMin)
    !***********************************************************************************************
-   ! PID regulation of generator torque 
+   ! PID regulation of generator torque
    !***********************************************************************************************
    call torquecontroller(GenSpeed, GenSpeedFilt, dGenSpeed_dtFilt, PitchMean, WSPfilt, PitchMin, &
                          GenSpeedRef_full, Pe, GenTorqueRef, dump_array)
@@ -152,7 +152,7 @@ subroutine normal_operation(GenSpeed, PitchVect, wsp, Pe, TTfa_acc, GenTorqueRef
    x = switch_spline(TimerGenCutin, CutinVar%delay, 2.0_mk*CutinVar%delay)
    GenTorqueRef = min(max(GenTorqueRef + Qdamp_ref*x, 0.0_mk), GenTorqueMax)
    !***********************************************************************************************
-   ! PID regulation of collective pitch angle  
+   ! PID regulation of collective pitch angle
    !***********************************************************************************************
    call pitchcontroller(GenSpeedFilt, dGenSpeed_dtFilt, PitchMeanFilt, Pe, PitchMin, &
                         GenSpeedRef_full, PitchColRef, dump_array)
@@ -194,7 +194,7 @@ subroutine start_up(CtrlStatus, GenSpeed, PitchVect, wsp, GenTorqueRef, PitchCol
    PitchMean = (PitchVect(1) + PitchVect(2) + PitchVect(3)) / 3.0_mk
    PitchMeanFilt = lowpass1orderfilt(deltat, stepno, pitchfirstordervar, PitchMean)
    PitchMeanFilt = min(PitchMeanFilt, 30.0_mk*degrad)
-   ! Low-pass filtering of the nacelle wind speed 
+   ! Low-pass filtering of the nacelle wind speed
    WSPfilt = lowpass1orderfilt(deltat, stepno, wspfirstordervar, wsp)
    ! Minimum pitch angle may vary with filtered wind speed
    PitchMin = GetOptiPitch(WSPfilt)
@@ -313,8 +313,8 @@ subroutine shut_down(CtrlStatus, GenSpeed, PitchVect, wsp, GenTorqueRef, PitchCo
    end select
    ! Pitch seetings
    select case(CtrlStatus)
-     case(1, 3, 4) ! Two pitch speed stop 
-       if (TimerShutdown2 .gt. CutoutVar%pitchdelay + CutoutVar%pitchdelay2) then 
+     case(1, 3, 4) ! Two pitch speed stop
+       if (TimerShutdown2 .gt. CutoutVar%pitchdelay + CutoutVar%pitchdelay2) then
          PitchColRef = min(PitchStopAng, PitchColRefOld + deltat*CutoutVar%pitchvelmax2)
        elseif (TimerShutdown2 .gt. CutoutVar%pitchdelay) then
          PitchColRef = min(PitchStopAng, PitchColRefOld + deltat*CutoutVar%pitchvelmax)
@@ -355,7 +355,7 @@ subroutine monitoring(CtrlStatus, GridFlag, GenSpeed, TTAcc, dump_array)
    y = lowpass2orderfilt(deltat, stepno, MoniVar%omega2ordervar, GenSpeed)
    GenSpeedFilt = y(1)
    dGenSpeed_dtFilt = y(2)
-   ! Low-pass filtering of the nacelle wind speed 
+   ! Low-pass filtering of the nacelle wind speed
    TTAccFilt = lowpass1orderfilt(deltat, stepno, MoniVar%rystevagtfirstordervar, TTAcc)
    !***********************************************************************************************
    ! Grid monitoring
@@ -436,11 +436,11 @@ subroutine torquecontroller(GenSpeed, GenSpeedFilt, dGenSpeed_dtFilt, PitchMean,
    !-----------------------------------------------------------------------------------------------
    ! Limits for full load
    !-----------------------------------------------------------------------------------------------
-   if (const_power) then 
+   if (const_power) then
      GenTorqueMin_full = min((GenTorqueRated*GenSpeedRef_full)/max(GenSpeed, GenSpeedRefMin), &
                               GenTorqueMax)
      GenTorqueMax_full = GenTorqueMin_full
-   else 
+   else
      GenTorqueMin_full = GenTorqueRated
      GenTorqueMax_full = GenTorqueMin_full
    endif
@@ -449,7 +449,7 @@ subroutine torquecontroller(GenSpeed, GenSpeedFilt, dGenSpeed_dtFilt, PitchMean,
    !-----------------------------------------------------------------------------------------------
    select case (PartialLoadControlMode)
      ! Torque limits for K Omega^2 control of torque
-     case (1) 
+     case (1)
        ! Calculate the constant limits for opening and closing of torque limits
        GenSpeed_min1 = GenSpeedRefMin
        GenSpeed_min2 = GenSpeedRefMin/SwitchVar%rel_sp_open_Qg
@@ -560,7 +560,7 @@ end subroutine
 subroutine rotorspeedexcl(GenSpeedFilt, GenTorque, Qg_min_partial, GenTorqueMax_partial, GenSpeedFiltErr, &
                           outmax, outmin, dump_array)
    !
-   ! Rotor speed exclusion zone. Subroutine that changes the generator torque limits and the 
+   ! Rotor speed exclusion zone. Subroutine that changes the generator torque limits and the
    ! generator speed error for the generator PID controller to avoid a rotor speed band.
    !
    real(mk), intent(in) :: GenSpeedFilt         ! Filtered measured generator speed [rad/s].


### PR DESCRIPTION
For consistency, make sure all doubles are of type `_mk`. Since HAWC2 is expecting all of the DLL IO to be of type doubles, only use doubles and do not use integers for status flags.

Since many editors auto trim trailing spaces (they are totally redundant), there are also a number of trailing white space "fixes".

@mhmdmirzaei, can you review this PR?
