### PR TITLE
Pitch ref from start-up to operation fix

### DIFF
--- a/src/dtu_we_controller/turbine_controller.f90
+++ b/src/dtu_we_controller/turbine_controller.f90
@@ -255,7 +255,11 @@ subroutine start_up(CtrlStatus, GenSpeed, PitchVect, wsp, GenTorqueRef, PitchCol
       PID_gen_var%outmin = GenTorqueRef
       kgain_torque = 1.0_mk
       dummy = PID(stepno, deltat, kgain_torque, PID_gen_var, GenSpeedFiltErr)
+      ! Remember pitch reference for transition
+      PitchColRef0 = PitchColRef
    else
+      ! Set pitch reference
+      PitchColRef  = PitchColRef0
       GenTorqueRef = GenTorqueRef0
       ! Done with start-up
       CtrlStatus = 0


### PR DESCRIPTION
The pitch reference was seen to not be stored when the controller goes from status=-1 to status=0, which resulted in a large pitch step. This PR was found to solve the problem.