### PR TITLE
Creating "git_version.inc" directly

### DIFF
--- a/src/get_git_version.bat
+++ b/src/get_git_version.bat
@@ -13,6 +13,7 @@ git rev-list %last_tag%..HEAD --count > tmp.txt
 set /p rev_count_since_tag=<tmp.txt
 
 echo %last_tag%.dev%rev_count_since_tag%.%rev_hash% > git_version.txt
-del tmp.txt
 
-VersionScript.exe
+echo text35='%last_tag%.dev%rev_count_since_tag%.%rev_hash%' > ./src/dtu_we_controller/git_version.inc
+
+del tmp.txt


### PR DESCRIPTION
Avoided using "VersionScript" to create the "git_version.inc" and move to correct folder. Just a suggestion, which seems to work very well.